### PR TITLE
Ignore preamp token for now

### DIFF
--- a/autoeq/fixed_band.go
+++ b/autoeq/fixed_band.go
@@ -21,7 +21,6 @@ type FixedBandEQs []FixedBandEQ
 func ToFixedBandEQs(data []byte) (FixedBandEQs, error) {
 	var eqs FixedBandEQs
 	rows := strings.Split(string(data), "\n")
-	fmt.Printf("Got: %s\n", string(data))
 	for _, row := range rows {
 		if row == "" {
 			continue
@@ -29,9 +28,7 @@ func ToFixedBandEQs(data []byte) (FixedBandEQs, error) {
 		if strings.HasPrefix(row, "Preamp") {
 			continue
 		}
-		fmt.Printf("Got: %s\n", string(row))
 		eqFields := strings.Fields(row)
-		fmt.Printf("Got: %s\n", eqFields)
 		freq, err := strconv.Atoi(eqFields[5])
 		if err != nil {
 			return nil, fmt.Errorf("could not parse frequency: %w", err)

--- a/autoeq/fixed_band.go
+++ b/autoeq/fixed_band.go
@@ -21,11 +21,17 @@ type FixedBandEQs []FixedBandEQ
 func ToFixedBandEQs(data []byte) (FixedBandEQs, error) {
 	var eqs FixedBandEQs
 	rows := strings.Split(string(data), "\n")
+	fmt.Printf("Got: %s\n", string(data))
 	for _, row := range rows {
 		if row == "" {
 			continue
 		}
+		if strings.HasPrefix(row, "Preamp") {
+			continue
+		}
+		fmt.Printf("Got: %s\n", string(row))
 		eqFields := strings.Fields(row)
+		fmt.Printf("Got: %s\n", eqFields)
 		freq, err := strconv.Atoi(eqFields[5])
 		if err != nil {
 			return nil, fmt.Errorf("could not parse frequency: %w", err)


### PR DESCRIPTION
Some settings contain a preamp token that we are not able to process currently. For now, we can skip this token but need to figure out a long-term solution.