### PR TITLE
Upgrade actions to Go 1.16.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.2
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: "1.16.2"
       - run: go test -race -cover ./...


### PR DESCRIPTION
## CHANGELOG

Upgrade Go version to 1.16.2 in PR and release actions
