### PR TITLE
Added Dockerfile and sample usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ By default `autoEqMac` saves a JSON file with the same name of the headphones mo
 
 You can provide a different path by passing it using the `-f, --file` flag.
 
+## Running with Docker
+
+Docker can be used in order to execute autoEqMac without installing the Golan runtime environmnet.
+
+Build Image:
+
+```
+ docker build -t autoEqMac .
+```
+
+And then, to run autoEqMac:
+
+```
+docker run --rm -it -v $(pwd):/app autoEqMac
+```
+
+
 ## TODO
 - [ ] GUI
 


### PR DESCRIPTION
Oftentimes it's easier to run tools such as autoEqMac in a Docker container. I added a Dockerfile that uses the latest official Golang image and then builds autoEqMac.

Running instructions added to the README.