### PR TITLE
[ISSUE-28] Update preamp fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ An interactive CLI that retrieves headphones EQ data from the [AutoEq Project](h
 
 ### Install
 
+Download the latest [release](https://github.com/indiependente/autoEqMac/releases/latest).
+
+### Install with Go
+
 ```bash
 go install github.com/indiependente/autoEqMac
 ```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/indiependente/autoEqMac)](https://goreportcard.com/report/github.com/indiependente/autoEqMac)
 <a href='https://github.com/jpoles1/gopherbadger' target='_blank'>![gopherbadger-tag-do-not-edit](https://img.shields.io/badge/Go%20Coverage-63%25-brightgreen.svg?longCache=true&style=flat)</a>
 [![Workflow Status](https://github.com/indiependente/autoEqMac/workflows/lint-test/badge.svg)](https://github.com/indiependente/autoEqMac/actions)
+
 # autoEqMac
+
 An interactive CLI that retrieves headphones EQ data from the [AutoEq Project](https://github.com/jaakkopasanen/AutoEq) and produces a JSON preset ready to be imported into [EqMac](https://github.com/bitgapp/eqMac/).
 
 ## Dependencies
- - Go
+
+- Go
 
 ## How to
 
 ### Install
 
-`go install github.com/indiependente/autoEqMac`
+```bash
+go install github.com/indiependente/autoEqMac
+```
 
 ### Supported commands
 
-```
+```plaintext
 ▶ autoEqMac --help
 usage: autoEqMac [<flags>]
 
@@ -42,11 +47,13 @@ By default `autoEqMac` saves a JSON file with the same name of the headphones mo
 You can provide a different path by passing it using the `-f, --file` flag.
 
 ## TODO
+
 - [ ] GUI
 
 ## Credits
 
 Thanks to:
- - https://github.com/jaakkopasanen/AutoEq
- - https://github.com/bitgapp/eqMac/
- - https://github.com/c-bata/go-prompt
+
+- <https://github.com/jaakkopasanen/AutoEq>
+- <https://github.com/bitgapp/eqMac/>
+- <https://github.com/c-bata/go-prompt>

--- a/autoeq/fixed_band.go
+++ b/autoeq/fixed_band.go
@@ -1,12 +1,19 @@
 package autoeq
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 )
 
-const fixedBandFields = 12
+const (
+	preampFields    = 3
+	fixedBandFields = 12
+)
+
+// ErrBadPreampFormat is returned when the preamp line can't be parsed.
+var ErrBadPreampFormat = errors.New("bad preamp line format")
 
 // FixedBandFilter represents a single EQ band.
 type FixedBandFilter struct {
@@ -34,7 +41,11 @@ func ToFixedBandEQs(data []byte) (*FixedBandEQ, error) {
 
 	// parse preamp
 	if strings.HasPrefix(rows[0], "Preamp") {
-		preamp, err := strconv.ParseFloat(strings.TrimSpace(strings.Fields(rows[0])[1]), bitSize)
+		fields := strings.Fields(rows[0])
+		if len(fields) != preampFields {
+			return nil, ErrBadPreampFormat
+		}
+		preamp, err := strconv.ParseFloat(strings.TrimSpace(fields[1]), bitSize)
 		if err != nil {
 			return nil, err
 		}

--- a/autoeq/fixed_band.go
+++ b/autoeq/fixed_band.go
@@ -25,24 +25,29 @@ type FixedBandEQ struct {
 // Returns an error if any.
 func ToFixedBandEQs(data []byte) (*FixedBandEQ, error) {
 	rows := strings.Split(string(data), "\n")
+
 	fbEQ := &FixedBandEQ{
 		Filters: make([]*FixedBandFilter, len(rows)),
 	}
 
+	startIdx := 0 // rows index, increment if first row is preamp
+
+	// parse preamp
+	if strings.HasPrefix(rows[0], "Preamp") {
+		preamp, err := strconv.ParseFloat(strings.TrimSpace(strings.Fields(rows[0])[1]), bitSize)
+		if err != nil {
+			return nil, err
+		}
+		fbEQ.Preamp = preamp
+		startIdx++
+	}
+
 	i := 0
-	for _, row := range rows {
+	for _, row := range rows[startIdx:] {
 		if row == "" {
 			continue
 		}
-		if strings.HasPrefix(row, "Preamp") {
-			preamp, err := strconv.ParseFloat(strings.TrimSpace(strings.Fields(row)[1]), bitSize)
-			if err != nil {
-				return nil, err
-			}
-			fbEQ.Preamp = preamp
 
-			continue
-		}
 		eqFields := strings.Fields(row)
 		if len(eqFields) < fixedBandFields {
 			return nil, fmt.Errorf("could not parse : %s", row)

--- a/autoeq/fixed_band_test.go
+++ b/autoeq/fixed_band_test.go
@@ -12,13 +12,16 @@ func TestToFixedBandEQs(t *testing.T) {
 	tests := []struct {
 		name    string
 		data    []byte
-		want    FixedBandEQs
+		want    *FixedBandEQ
 		wantErr bool
 	}{
 		{
-			name:    "Happy path",
-			data:    []byte("Filter 1: ON PK Fc 31 Hz Gain 5.8 dB Q 1.41\n"),
-			want:    FixedBandEQs{{Frequency: 31, Gain: 5.8, Q: 1.41}},
+			name: "Happy path",
+			data: []byte("Preamp: -6.1 dB\nFilter 1: ON PK Fc 31 Hz Gain 5.8 dB Q 1.41\n"),
+			want: &FixedBandEQ{
+				Filters: []*FixedBandFilter{{Frequency: 31, Gain: 5.8, Q: 1.41}},
+				Preamp:  -6.1,
+			},
 			wantErr: false,
 		},
 		{

--- a/autoeq/fixed_band_test.go
+++ b/autoeq/fixed_band_test.go
@@ -25,6 +25,12 @@ func TestToFixedBandEQs(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Happy path - No data",
+			data:    nil,
+			want:    &FixedBandEQ{Filters: []*FixedBandFilter{}, Preamp: 0},
+			wantErr: false,
+		},
+		{
 			name:    "Sad path - Freq not int",
 			data:    []byte("Filter 1: ON PK Fc AB Hz Gain 5.8 dB Q 1.41"),
 			want:    nil,
@@ -39,6 +45,12 @@ func TestToFixedBandEQs(t *testing.T) {
 		{
 			name:    "Sad path - Q not float",
 			data:    []byte("Filter 1: ON PK Fc 31 Hz Gain 5.8 dB Q AB"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Sad path - Bad Preamp Line Format",
+			data:    []byte("Preamp: -6.1\nFilter 1: ON PK Fc AB Hz Gain 5.8 dB Q 1.41"),
 			want:    nil,
 			wantErr: true,
 		},

--- a/autoeq/mdparser.go
+++ b/autoeq/mdparser.go
@@ -21,6 +21,7 @@ type EQMetadata struct {
 	Name   string
 	Author string
 	Link   string
+	// Deprecated: this field has been deprecated in favor of autoeq.FixedBandEQ.Preamp.
 	Global float64
 }
 

--- a/eqmac/mapping/mapper.go
+++ b/eqmac/mapping/mapper.go
@@ -22,7 +22,7 @@ func (g WrappedGenerator) UUID() string {
 
 // Mapper defines the behavior of a component capable of mapping AutoEQ data into EqMac format.
 type Mapper interface {
-	MapFixedBand(autoeq.FixedBandEQs, *autoeq.EQMetadata) (eqmac.EQPreset, error)
+	MapFixedBand(*autoeq.FixedBandEQ, *autoeq.EQMetadata) (eqmac.EQPreset, error)
 }
 
 // compile time interface implementation check.
@@ -43,17 +43,17 @@ func NewAutoEQMapper(gen UUIDGenerator) AutoEQMapper {
 
 // MapFixedBand maps fixed bands EQ data into an EqMac preset.
 // Returns an error if any.
-func (m AutoEQMapper) MapFixedBand(fbeq autoeq.FixedBandEQs, meta *autoeq.EQMetadata) (eqmac.EQPreset, error) {
+func (m AutoEQMapper) MapFixedBand(fbeq *autoeq.FixedBandEQ, meta *autoeq.EQMetadata) (eqmac.EQPreset, error) {
 	var preset eqmac.EQPreset
 	preset.ID = m.gen.UUID()
 	preset.IsDefault = false
 	preset.Name = meta.Name
 	preset.Gains = eqmac.Gains{
-		Global: meta.Global,
+		Global: fbeq.Preamp,
 		Bands:  []float64{},
 	}
 	bands := []float64{}
-	for _, band := range fbeq {
+	for _, band := range fbeq.Filters {
 		bands = append(bands, band.Gain)
 	}
 	preset.Gains.Bands = bands

--- a/eqmac/mapping/mapper_mock.go
+++ b/eqmac/mapping/mapper_mock.go
@@ -70,7 +70,7 @@ func (m *MockMapper) EXPECT() *MockMapperMockRecorder {
 }
 
 // MapFixedBand mocks base method
-func (m *MockMapper) MapFixedBand(arg0 autoeq.FixedBandEQs, arg1 autoeq.EQMetadata) (eqmac.EQPreset, error) {
+func (m *MockMapper) MapFixedBand(arg0 autoeq.FixedBandEQ, arg1 autoeq.EQMetadata) (eqmac.EQPreset, error) {
 	ret := m.ctrl.Call(m, "MapFixedBand", arg0, arg1)
 	ret0, _ := ret[0].(eqmac.EQPreset)
 	ret1, _ := ret[1].(error)

--- a/eqmac/mapping/mapper_test.go
+++ b/eqmac/mapping/mapper_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/indiependente/autoEqMac/eqmac"
 )
 
-func TestAutoEQMapper_MapFixedBand(t *testing.T) {
+func TestAutoEQMapper_MapFixedBand(t *testing.T) { //nolint: funlen
 	t.Parallel()
 	id := uuid.New().String()
 	type args struct {
-		fbeq autoeq.FixedBandEQs
+		fbeq *autoeq.FixedBandEQ
 		meta *autoeq.EQMetadata
 	}
 	tests := []struct {
@@ -28,12 +28,13 @@ func TestAutoEQMapper_MapFixedBand(t *testing.T) {
 		{
 			name: "Happy path",
 			args: args{
-				fbeq: autoeq.FixedBandEQs{
-					{
+				fbeq: &autoeq.FixedBandEQ{
+					Preamp: -6.4,
+					Filters: []*autoeq.FixedBandFilter{{
 						Frequency: 31,
 						Gain:      5.8,
 						Q:         1.41,
-					},
+					}},
 				},
 				meta: &autoeq.EQMetadata{
 					ID:     "0",

--- a/executor.go
+++ b/executor.go
@@ -58,5 +58,7 @@ func NewExecutor(srv *server.HTTPServer) func(string) {
 			return
 		}
 		fmt.Printf("📝 Preset saved to %s\n", f.Name())
+
+		os.Exit(0)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -22,8 +22,10 @@ from the same source.
 
 - [Audio-Technica ATH-M50x](./oratory1990/harman_over-ear_2018/Audio-Technica%20ATH-M50x) by oratory1990
 `)
-	rawEqData     = []byte(`Filter 1: ON PK Fc 31 Hz Gain 5.8 dB Q 1.41`)
-	rawGlobalData = []byte(`# Audio-Technica ATH-M50x
+	rawEqData = []byte(`Preamp: -6.4 dB
+	Filter 1: ON PK Fc 31 Hz Gain 5.8 dB Q 1.41`)
+	rawEqDataNoPreamp = []byte(`Filter 1: ON PK Fc 31 Hz Gain 5.8 dB Q 1.41`)
+	rawGlobalData     = []byte(`# Audio-Technica ATH-M50x
 See [usage instructions](https://github.com/jaakkopasanen/AutoEq#usage) for more options and info.
 
 ### Parametric EQs
@@ -104,6 +106,30 @@ func TestHTTPServer(t *testing.T) { //nolint:funlen
 				doer.EXPECT().Do(gomock.Any()).Return(&http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader(rawEqData)),
+				}, nil)
+			},
+			want: struct {
+				meta   []*autoeq.EQMetadata
+				preset eqmac.EQPreset
+			}{
+				meta: []*autoeq.EQMetadata{
+					eqMeta,
+				},
+				preset: eqPreset,
+			},
+
+			wantErr: false,
+		},
+		{
+			name: "Happy path - Missing Global Preamp requires extra HTTP call",
+			setupExpectations: func(doer *MockDoer) {
+				doer.EXPECT().Do(gomock.Any()).Return(&http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(rawEqList)),
+				}, nil)
+				doer.EXPECT().Do(gomock.Any()).Return(&http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(rawEqDataNoPreamp)),
 				}, nil)
 				doer.EXPECT().Do(gomock.Any()).Return(&http.Response{
 					StatusCode: http.StatusOK,


### PR DESCRIPTION
## Issue

As raised in https://github.com/indiependente/autoEqMac/issues/28, the preamp value is fetched in a suboptimal way that involves MarkDown parsing, which could result in unreliable data.

## Solution

The preamp value fetching code has been updated to match the newly introduced file format for fixed bands EQ, that contains the needed value on the first row in dB.
